### PR TITLE
Fixing method name and updating version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.evcode.queryfy</groupId>
     <artifactId>queryfy-root</artifactId>
-    <version>1.2.1-SNAPSHOT</version>
+    <version>1.2.2-SNAPSHOT</version>
 
     <modules>
         <module>queryfy-core</module>

--- a/queryfy-core/pom.xml
+++ b/queryfy-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>queryfy-root</artifactId>
         <groupId>org.evcode.queryfy</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/queryfy-mongodb/pom.xml
+++ b/queryfy-mongodb/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <artifactId>queryfy-root</artifactId>
         <groupId>org.evcode.queryfy</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
     </parent>
 
     <properties>

--- a/queryfy-mongodb/src/main/java/org/evcode/queryfy/mongodb/MongodbQueryParser.java
+++ b/queryfy-mongodb/src/main/java/org/evcode/queryfy/mongodb/MongodbQueryParser.java
@@ -35,11 +35,11 @@ public class MongodbQueryParser {
         return evaluationResult;
     }
 
-    public <T> FindIterable<T> parseAndfind(MongoCollection<T> collection, String expression, MongodbContext context) {
-        return parseAndfind(collection, expression, context, ParserConfig.DEFAULT);
+    public <T> FindIterable<T> parseAndFind(MongoCollection<T> collection, String expression, MongodbContext context) {
+        return parseAndFind(collection, expression, context, ParserConfig.DEFAULT);
     }
 
-    public <T> FindIterable<T> parseAndfind(MongoCollection<T> collection, String expression, MongodbContext context, ParserConfig config) {
+    public <T> FindIterable<T> parseAndFind(MongoCollection<T> collection, String expression, MongodbContext context, ParserConfig config) {
         FindIterable<T> query = collection.find();
         return parseAndApply(query, expression, context, config);
     }

--- a/queryfy-querydsl/pom.xml
+++ b/queryfy-querydsl/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>queryfy-root</artifactId>
         <groupId>org.evcode.queryfy</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/queryfy-querydsl/queryfy-querydsl-core/pom.xml
+++ b/queryfy-querydsl/queryfy-querydsl-core/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>queryfy-querydsl</artifactId>
         <groupId>org.evcode.queryfy</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/queryfy-querydsl/queryfy-querydsl-jpa/pom.xml
+++ b/queryfy-querydsl/queryfy-querydsl-jpa/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>queryfy-querydsl</artifactId>
         <groupId>org.evcode.queryfy</groupId>
-        <version>1.2.1-SNAPSHOT</version>
+        <version>1.2.2-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
Fixed method name from `parseAndfind` to `parseAndFind `